### PR TITLE
Added better client id handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Pipfile*
 */*
+client_id*


### PR DESCRIPTION
Added some functions to aid the user in finding and setting the Twitch client id. If no client id is provided, the script will prompt the user with instructions to get one, then input it and save it to a file. Most importantly, added a text file that the script will check at runtime for the client id. It is still possible to edit the script to have your client id like before. You can also override the client id by providing it on the command line with the -c,--client-id=ID flags.