### PR TITLE
prevent double timer initialisation

### DIFF
--- a/check.py
+++ b/check.py
@@ -162,10 +162,10 @@ def main():
         check_client_id()
 
     
-    t = Timer(time, loopcheck)
+#    t = Timer(time, loopcheck)
     print("Checking for",user,"every",time,"seconds. Record with",quality,"quality.")
     loopcheck()
-    t.start()
+#    t.start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As loopcheck() already starts the timer, there is no need to start it in main().
This prevents the occasional "double recording", as I call it.
Happens to me every time a stream ends and a new one starts.