### PR TITLE
feat: Add download folder option

### DIFF
--- a/ATRHandler.py
+++ b/ATRHandler.py
@@ -128,6 +128,7 @@ class ATRHandler(BaseHTTPRequestHandler):
             'remove': self.cmd_remove,
             'add': self.cmd_add,
             'time': self.cmd_time,
+            'download_folder': self.cmd_download_folder,
         }
         func = cmd_executor[post_data['cmd']]
         if len(post_data['args']) > 0:
@@ -173,6 +174,14 @@ class ATRHandler(BaseHTTPRequestHandler):
     def cmd_time(self, args):
         try:
             self.message['println'] = self.server.set_interval(int(args[0]))
+            self.ok = True
+        except ValueError:
+            self.ok = False
+            self.message['println'] = '\'' + args[0] + '\' is not valid.'
+    
+    def cmd_download_folder(self, args):
+        try:
+            self.message['println'] = self.server.set_download_folder(str(args[0]).strip())
             self.ok = True
         except ValueError:
             self.ok = False

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Checks if a user on twitch is currently streaming and then records the stream vi
   - `start`: starts checking for / recording all added streamers
   - `list`: prints all added streamers
   - `exit`: stops the application and all currently running recordings
+  - `download_folder path`: sets the download folder for saving the recordings. (#streamer# will be replaced with the name of the streamer)
 
 Example inputs to record forsen and nymn (this will also repeatedly check if they are online):
 

--- a/atr_cmd.py
+++ b/atr_cmd.py
@@ -21,7 +21,6 @@ class AtrCmd(cmd.Cmd):
         return payload
 
     def __init__(self):
-        # self.daemon = Daemon()
         super().__init__()
 
     def do_add(self, line):
@@ -79,6 +78,16 @@ class AtrCmd(cmd.Cmd):
             'Configures the check interval in seconds.',
             'It\'s advised not to make it too low and to stay above 10 seconds.',
             'Default check interval: 30 seconds.',
+        ]))
+
+    def do_download_folder(self, line):
+        payload = self._create_payload('download_folder', line)
+        self._send_cmd(payload)
+
+    def help_download_folder(self):
+        print('\n'.join([
+            'download_folder path',
+            'Configures the download folder for saving the videos.',
         ]))
 
     def do_EOF(self, line):

--- a/watcher.py
+++ b/watcher.py
@@ -12,12 +12,13 @@ class Watcher:
     kill = False
     cleanup = False
 
-    def __init__(self, streamer_dict):
+    def __init__(self, streamer_dict, download_folder):
         self.streamer_dict = streamer_dict
         self.streamer = self.streamer_dict['user_info']['display_name']
         self.streamer_login = self.streamer_dict['user_info']['login']
         self.stream_title = self.streamer_dict['stream_info']['title']
         self.stream_quality = self.streamer_dict['preferred_quality']
+        self.download_folder = download_folder
 
     def quit(self):
         self.kill = True
@@ -28,7 +29,7 @@ class Watcher:
     def watch(self):
         curr_time = datetime.datetime.now().strftime("%Y-%m-%d %H.%M.%S")
         file_name = curr_time + " - " + self.streamer + " - " + get_valid_filename(self.stream_title) + ".ts"
-        directory = os.getcwd() + os.path.sep + self.streamer_login + os.path.sep
+        directory = self._formatted_download_folder(self.streamer_login) + os.path.sep
         if not os.path.exists(directory):
             os.makedirs(directory)
         output_filepath = directory + file_name
@@ -95,3 +96,6 @@ class Watcher:
             self.streamer_dict.update({'kill': self.kill})
             self.streamer_dict.update({'cleanup': self.cleanup})
             return self.streamer_dict
+
+    def _formatted_download_folder(self, streamer):
+        return self.download_folder.replace('#streamer#', streamer)


### PR DESCRIPTION
Adds an extra command to set a custom download folder.
This change is backward compatible with the previous functionality.

When including `#streamer#` in the path it will be replaced with the name of the streamer.

Tested it on a Mac / Unix system. Don't know for sure if this will play well on a Windows machine.

Fixes: #33