### PR TITLE
Use 'user_login' instead of 'user_name'

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -100,7 +100,7 @@ class Daemon(HTTPServer):
 
             # save streaming information for all streamers, if it exists
             for stream_info in streams_info:
-                streamer_name = stream_info['user_name'].lower()
+                streamer_name = stream_info['user_login']
                 self.streamers[streamer_name].update({'stream_info': stream_info})
 
             live_streamers = []
@@ -110,7 +110,7 @@ class Daemon(HTTPServer):
                 try:
                     stream_info = streamer_info['stream_info']
                     if stream_info['type'] == 'live':
-                        live_streamers.append(stream_info['user_name'].lower())
+                        live_streamers.append(stream_info['user_login'])
                 except KeyError:
                     pass
 


### PR DESCRIPTION
user_name = Streamer's display name, user_login = Streamer's Twitch ID

Twitch has two types of name.
In general, English countries use their ID directly as channel name but the other doesn't. They use display name instead.

Fixes: #44